### PR TITLE
Unix new line bugfix

### DIFF
--- a/ERezeptClientSimpleExample/ERezeptClientSimpleExample/Program.cs
+++ b/ERezeptClientSimpleExample/ERezeptClientSimpleExample/Program.cs
@@ -92,14 +92,14 @@ namespace ERezeptClientSimpleExample {
 </Parameters>";
 
                 var binaryContent = Encoding.UTF8.GetBytes(contentbody);
-                string content = $@"POST /Task/$create HTTP/1.1
-Host: {new Uri(EREZEPT_FACHDIENST_URL).Host}
-Authorization: Bearer {bearerPraxis}
-Content-Type: application/fhir+xml
-Accept: application/fhir+xml;charset=utf-8
-Content-Length: {binaryContent.Length}
+                string content = $"POST /Task/$create HTTP/1.1\r\n" +
+                                 $"Host: {new Uri(EREZEPT_FACHDIENST_URL).Host}\r\n" +
+                                 $"Authorization: Bearer {bearerPraxis}\r\n" +
+                                 $"Content-Type: application/fhir+xml\r\n" +
+                                 $"User-Agent: {USER_AGENT}\r\n" +
+                                 $"Accept: application/fhir+xml;charset=utf-8\r\n" +
+                                 $"Content-Length: { binaryContent.Length}\r\n\r\n";
 
-";
                 var vau = new VAU(USER_AGENT, EREZEPT_FACHDIENST_URL);
 
                 string requestid = VAU.ByteArrayToHexString(vau.GetRandom(16));
@@ -167,13 +167,12 @@ Content-Length: {binaryContent.Length}
                     .GetBearerToken(tokenForApothekeWhenMultipleSmcbFound : true);
                 Console.Out.WriteLine($"Get Bearer-Token ({sw.ElapsedMilliseconds}ms) = " + bearer);
 
-                string content = $@"POST /Task/{taskid}/$accept?ac={accesscode} HTTP/1.1
-Host: {new Uri(EREZEPT_FACHDIENST_URL).Host}
-Authorization: Bearer {bearer}
-Content-Type: application/fhir+xml
-Accept: application/fhir+xml;charset=utf-8
-
-"; //2 Newlines am Ende sind wichtig wegen RFC-HTTP
+                string content = $"POST /Task/{taskid}/$accept?ac={accesscode} HTTP/1.1\r\n" +
+                                 $"Host: {new Uri(EREZEPT_FACHDIENST_URL).Host}\r\n" +
+                                 $"Authorization: Bearer {bearer}\r\n" +
+                                 $"Content-Type: application/fhir+xml\r\n" +
+                                 $"User-Agent: {USER_AGENT}\r\n" +
+                                 $"Accept: application/fhir+xml;charset=utf-8\r\n\r\n"; //2 Newlines am Ende sind wichtig wegen RFC-HTTP
 
                 var vau = new VAU(USER_AGENT, EREZEPT_FACHDIENST_URL); 
 


### PR DESCRIPTION
Dateien werden in git je nach Konfiguration mit Unix-style Zeilen Umbrüchen encodiert. Gemäß RFC-2616 müssen die header allerdings nach dem Windows Format getrennt werden. Daher kam es in dem neuen Release von Titus zu diesem Fehler:

```
java.lang.RuntimeException: javax.crypto.AEADBadTagException: mac check in GCM failed
```

```
Response body: {"timestamp":"2022-01-21T10:27:30.650+0000","path":"/VAU/0","status":500,"error":"Internal Server Error","message":"java.lang.RuntimeException: javax.crypto.AEADBadTagException: mac check in GCM failed","requestId":"3663610e-10492"}
```

Mit dieser Änderung sollten die Zeilenumbrüche auf jedem System korrekt sein. 